### PR TITLE
QLP code with polynomial entries

### DIFF
--- a/doc/intro.ipynb
+++ b/doc/intro.ipynb
@@ -26,7 +26,7 @@
     "### Hypergraph product (HGP) code\n",
     "\n",
     "Load the parity check matrix of the classical LDPC code stored in '../parity_check_matrices' directory.  \n",
-    "The parity check matrix `h` is found from `quits.ldpc_utility.generate_ldpc`, following the method in A. Grospellier, *Constant time decoding of quantum expander codes and application to fault-tolerant quantum computation* (2019)."
+    "The parity check matrix `h` is found from `quits.ldpc_utility.generate_ldpc`, following the method in [A. Grospellier, *Constant time decoding of quantum expander codes and application to fault-tolerant quantum computation* (2019)]."
    ]
   },
   {
@@ -101,7 +101,7 @@
    "source": [
     "### Quasi-cyclic lifted product (QLP) code\n",
     "\n",
-    "The base matrix `b` is brought from Q. Xu et al., *Nat. Phys.* 20, 1084 (2024). Each entry represents the exponent of the monomial. "
+    "The base matrix `b` is brought from [Q. Xu et al., arXiv:2308.08648]. Each entry represents the exponent of the monomial. "
    ]
   },
   {
@@ -166,17 +166,86 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b766d08",
+   "id": "f3349673",
    "metadata": {},
    "source": [
-    "### Balanced product cyclic (BPC) code\n",
+    "### Lift-connected surface code\n",
     "\n",
-    "This code is introduced in R. Tiew & N. P. Breuckmann, arXiv:2411.03302. "
+    "QLP code can be constructed with polynomial entries using `QlpCode2`. Each entry is the list of power of the polynomial terms. \n",
+    "\n",
+    "As an example, we generate the circuit of the lift-connected surface code, brought from [J. Old, M. Rispler, and M. Müller, arXiv:2401.02911]. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "2926fd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lift_size = 5\n",
+    "b = [[[0], [0, 1], []],   # [e, e+x, 0]\n",
+    "     [[], [0], [0, 1]]]   # [0, e, e+x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "52b954ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# data qubits:  65  # logical qubits:  5\n",
+      "# z-check qubits:  30  # x-check qubits:  30\n",
+      "# layers of entangling gates:  8\n"
+     ]
+    }
+   ],
+   "source": [
+    "code = QlpCode2(b, b, lift_size)   # Define the QlpCode2 object\n",
+    "code.build_graph(seed=1)           # Build the Tanner graph and assign directions to its edges. \n",
+    "\n",
+    "num_zcheck, num_data = code.hz.shape\n",
+    "num_xcheck, num_data = code.hx.shape\n",
+    "num_logical = code.lz.shape[0]\n",
+    "depth = sum(list(code.num_colors.values())) \n",
+    "print('# data qubits: ', num_data, ' # logical qubits: ', num_logical)\n",
+    "print('# z-check qubits: ', num_zcheck, ' # x-check qubits: ', num_xcheck)\n",
+    "print('# layers of entangling gates: ', depth)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4036f923",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = 1e-3           # physical error rate\n",
+    "num_rounds = 15    # number of rounds (T-1)\n",
+    "basis = 'Z'        # 'Z' or 'X'\n",
+    "\n",
+    "circuit = stim.Circuit(get_qldpc_mem_circuit(code, p, p, p, p, num_rounds, basis=basis))\n",
+    "check_overlapping_CX(circuit)    # Check for overlapping CX gates in the same layer. Nothing should be printed.\n",
+    "#print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b766d08",
+   "metadata": {},
+   "source": [
+    "### Balanced product cyclic (BPC) code\n",
+    "\n",
+    "This code is introduced in [R. Tiew & N. P. Breuckmann, arXiv:2411.03302]. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "id": "68975ae8",
    "metadata": {},
    "outputs": [],
@@ -188,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "d1eb9f95",
    "metadata": {},
    "outputs": [
@@ -217,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "e5bdce14",
    "metadata": {},
    "outputs": [],
@@ -241,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "59700b1d",
    "metadata": {},
    "outputs": [
@@ -249,18 +318,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-<<<<<<< HEAD
-      "100%|██████████| 100/100 [00:09<00:00, 10.86it/s]"
-=======
-      "100%|██████████| 100/100 [00:09<00:00, 10.56it/s]"
->>>>>>> fc6a6621278b4313484c879ebe625b0f72a58531
+      "100%|██████████| 100/100 [00:09<00:00, 10.51it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p: 0.0020000, LFR: 0.0020286\n"
+      "p: 0.0020000, LFR: 0.0006698\n"
      ]
     },
     {
@@ -300,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "ef3b0a84-c13a-4d5f-800f-a72e7347af8b",
    "metadata": {},
    "outputs": [
@@ -308,11 +373,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-<<<<<<< HEAD
-      "100%|██████████| 100/100 [00:09<00:00, 10.83it/s]\n"
-=======
-      "100%|██████████| 100/100 [00:09<00:00, 10.56it/s]\n"
->>>>>>> fc6a6621278b4313484c879ebe625b0f72a58531
+      "100%|██████████| 100/100 [00:09<00:00, 10.51it/s]\n"
      ]
     }
    ],

--- a/doc/intro.ipynb
+++ b/doc/intro.ipynb
@@ -249,14 +249,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:09<00:00, 10.26it/s]"
+      "100%|██████████| 100/100 [00:09<00:00, 10.86it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p: 0.0020000, LFR: 0.0006698\n"
+      "p: 0.0020000, LFR: 0.0020286\n"
      ]
     },
     {
@@ -304,7 +304,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:09<00:00, 10.14it/s]\n"
+      "100%|██████████| 100/100 [00:09<00:00, 10.83it/s]\n"
      ]
     }
    ],
@@ -343,7 +343,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "qec",
    "language": "python",
    "name": "python3"
   },
@@ -357,7 +357,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/src/quits/qldpc_code.py
+++ b/src/quits/qldpc_code.py
@@ -35,7 +35,7 @@ class QldpcCode:
                     h[i*lift_size:(i+1)*lift_size, j*lift_size:(j+1)*lift_size] = self.get_circulant_mat(lift_size, h_base[i,j])
         return h
     
-    def lift_enc(self, lift_size, h_base_enc, h_base_enc_placeholder):
+    def lift_enc(self, lift_size, h_base_enc, h_base_placeholder):
         '''
         :param lift_size: Size of cyclic matrix to which each polynomial term is lifted. 
         :param h_base: Base matrix where each entry ENCODEs the powers of polynomial terms in base of lift_size.
@@ -45,7 +45,7 @@ class QldpcCode:
         h = np.zeros((h_base_enc.shape[0] * lift_size, h_base_enc.shape[1] * lift_size), dtype=int)
         for i in range(h_base_enc.shape[0]):
             for j in range(h_base_enc.shape[1]):
-                if h_base_enc_placeholder[i,j] != 0:
+                if h_base_placeholder[i,j] != 0:
                     hij_enc = h_base_enc[i,j]
                     if hij_enc == 0:                        
                         h[i*lift_size:(i+1)*lift_size, j*lift_size:(j+1)*lift_size] = self.get_circulant_mat(lift_size, 0)
@@ -548,46 +548,46 @@ class QlpCode2(QldpcCode):
         b1T_enc = np.zeros((self.n1, self.m1), dtype=int)
         b2_enc = np.zeros((self.m2, self.n2), dtype=int)
         b2T_enc = np.zeros((self.n2, self.m2), dtype=int)
-        b1_enc_placeholder = np.zeros((self.m1, self.n1), dtype=int)
-        b2_enc_placeholder = np.zeros((self.m2, self.n2), dtype=int)
+        self.b1_placeholder = np.zeros((self.m1, self.n1), dtype=int)
+        self.b2_placeholder = np.zeros((self.m2, self.n2), dtype=int)
 
         for i in range(self.m1):
             for j in range(self.n1):
                 if self.b1[i][j] == []:
                     continue
-                b1_enc_placeholder[i,j] = 1
+                self.b1_placeholder[i,j] = 1
 
                 bij, bTij = 0, 0
                 for k in range(len(self.b1[i][j])):
                     bij += self.lift_size**k * self.b1[i][j][k] 
-                    bTij += self.lift_size**k * (self.lift_size - self.b1[i][j][k]) % self.lift_size
+                    bTij += self.lift_size**k * ((self.lift_size - self.b1[i][j][k]) % self.lift_size)
                 b1_enc[i,j] = bij
-                b1T_enc[j,i] = bTij % self.lift_size
+                b1T_enc[j,i] = bTij 
 
         for i in range(self.m2):
             for j in range(self.n2):
                 if self.b2[i][j] == []:
                     continue
-                b2_enc_placeholder[i,j] = 1
+                self.b2_placeholder[i,j] = 1
 
                 bij, bTij = 0, 0
                 for k in range(len(self.b2[i][j])):
                     bij += self.lift_size**k * self.b2[i][j][k] 
-                    bTij += self.lift_size**k * (self.lift_size - self.b2[i][j][k]) % self.lift_size
+                    bTij += self.lift_size**k * ((self.lift_size - self.b2[i][j][k]) % self.lift_size)
                 b2_enc[i,j] = bij
-                b2T_enc[j,i] = bTij % self.lift_size
+                b2T_enc[j,i] = bTij 
 
         hz_base_enc = np.concatenate((np.kron(b2_enc, np.eye(self.n1, dtype=int)), 
                                   np.kron(np.eye(self.m2, dtype=int), b1T_enc)), axis=1)
         hx_base_enc = np.concatenate((np.kron(np.eye(self.n2, dtype=int), b1_enc), 
                                   np.kron(b2T_enc, np.eye(self.m1, dtype=int))), axis=1)
-        hz_base_enc_placeholder = np.concatenate((np.kron(b2_enc_placeholder, np.eye(self.n1, dtype=int)), 
-                                              np.kron(np.eye(self.m2, dtype=int), b1_enc_placeholder.T)), axis=1)
-        hx_base_enc_placeholder = np.concatenate((np.kron(np.eye(self.n2, dtype=int), b1_enc_placeholder), 
-                                              np.kron(b2_enc_placeholder.T, np.eye(self.m1, dtype=int))), axis=1)
+        hz_base_placeholder = np.concatenate((np.kron(self.b2_placeholder, np.eye(self.n1, dtype=int)), 
+                                              np.kron(np.eye(self.m2, dtype=int), self.b1_placeholder.T)), axis=1)
+        hx_base_placeholder = np.concatenate((np.kron(np.eye(self.n2, dtype=int), self.b1_placeholder), 
+                                              np.kron(self.b2_placeholder.T, np.eye(self.m1, dtype=int))), axis=1)
         
-        self.hz = self.lift(self.lift_size, hz_base_enc, hz_base_enc_placeholder)
-        self.hx = self.lift(self.lift_size, hx_base_enc, hx_base_enc_placeholder)
+        self.hz = self.lift_enc(self.lift_size, hz_base_enc, hz_base_placeholder)
+        self.hx = self.lift_enc(self.lift_size, hx_base_enc, hx_base_placeholder)
         self.lz, self.lx = compute_lz_and_lx(self.hx, self.hz)
 
     def build_graph(self, seed=1):
@@ -637,13 +637,14 @@ class QlpCode2(QldpcCode):
         self.check_qubits = np.concatenate((self.zcheck_qubits, self.xcheck_qubits))
         self.all_qubits = sorted(np.array(data_qubits + zcheck_qubits + xcheck_qubits))   
 
-        hedge_bool_list = self.get_classical_edge_bools(np.ones(self.b1.shape, dtype=int), seed)
-        vedge_bool_list = self.get_classical_edge_bools(np.ones(self.b2.shape, dtype=int), seed)
+        hedge_bool_list = self.get_classical_edge_bools(self.b1_placeholder, seed)
+        vedge_bool_list = self.get_classical_edge_bools(self.b2_placeholder, seed)
     
         edge_no = 0
         for i in range(self.m1):
             for j in range(self.n1):
-                shift = self.b1[i, j]
+                if self.b1_placeholder[i,j] == 0:
+                    continue
                 edge_bool = hedge_bool_list[(i, j)]
 
                 for l in range(self.lift_size):
@@ -653,14 +654,16 @@ class QlpCode2(QldpcCode):
                         else:
                             direction_ind = self.direction_inds['W']                                                 
 
-                        control = (k * (self.n1+self.m1) + self.n1 + i) * self.lift_size + (l + shift) % self.lift_size
-                        target = (k * (self.n1+self.m1) + j) * self.lift_size + l
-                        self.add_edge(edge_no, direction_ind, control, target)
-                        edge_no += 1
+                        for shift in self.b1[i][j]:
+                            control = (k * (self.n1+self.m1) + self.n1 + i) * self.lift_size + (l + shift) % self.lift_size
+                            target = (k * (self.n1+self.m1) + j) * self.lift_size + l
+                            self.add_edge(edge_no, direction_ind, control, target)
+                            edge_no += 1
 
         for i in range(self.m2):
             for j in range(self.n2):
-                shift = self.b2[i, j]
+                if self.b2_placeholder[i,j] == 0:
+                    continue
                 edge_bool = vedge_bool_list[(i, j)]
 
                 for l in range(self.lift_size):
@@ -670,10 +673,11 @@ class QlpCode2(QldpcCode):
                         else:
                             direction_ind = self.direction_inds['S']   
 
-                        control = (k + j * (self.n1 + self.m1)) * self.lift_size + l
-                        target = (k + (i + self.n2) * (self.n1 + self.m1)) * self.lift_size + (l + shift) % self.lift_size
-                        self.add_edge(edge_no, direction_ind, control, target)
-                        edge_no += 1
+                        for shift in self.b2[i][j]:
+                            control = (k + j * (self.n1 + self.m1)) * self.lift_size + l
+                            target = (k + (i + self.n2) * (self.n1 + self.m1)) * self.lift_size + (l + shift) % self.lift_size
+                            self.add_edge(edge_no, direction_ind, control, target)
+                            edge_no += 1
 
         # Color the edges of self.graph
         self.color_edges()

--- a/src/quits/qldpc_code.py
+++ b/src/quits/qldpc_code.py
@@ -22,6 +22,12 @@ class QldpcCode:
         return circulant(np.eye(size, dtype=int)[:,power])
 
     def lift(self, lift_size, h_base, h_base_placeholder):
+        '''
+        :param lift_size: Size of cyclic matrix to which each monomial entry is lifted. 
+        :param h_base: Base matrix where each entry is the power of the monomial.
+        :param h_base_placeholder: Placeholder matrix where each non-zero entry of the base matrix is replaced by 1.
+        :return: Lifted matrix.
+        '''
         h = np.zeros((h_base.shape[0] * lift_size, h_base.shape[1] * lift_size), dtype=int)
         for i in range(h_base.shape[0]):
             for j in range(h_base.shape[1]):
@@ -29,6 +35,28 @@ class QldpcCode:
                     h[i*lift_size:(i+1)*lift_size, j*lift_size:(j+1)*lift_size] = self.get_circulant_mat(lift_size, h_base[i,j])
         return h
     
+    def lift_enc(self, lift_size, h_base_enc, h_base_enc_placeholder):
+        '''
+        :param lift_size: Size of cyclic matrix to which each polynomial term is lifted. 
+        :param h_base: Base matrix where each entry ENCODEs the powers of polynomial terms in base of lift_size.
+        :param h_base_placeholder: Placeholder matrix where each non-zero entry of the base matrix is replaced by 1.
+        :return: Lifted matrix.
+        '''
+        h = np.zeros((h_base_enc.shape[0] * lift_size, h_base_enc.shape[1] * lift_size), dtype=int)
+        for i in range(h_base_enc.shape[0]):
+            for j in range(h_base_enc.shape[1]):
+                if h_base_enc_placeholder[i,j] != 0:
+                    hij_enc = h_base_enc[i,j]
+                    if hij_enc == 0:                        
+                        h[i*lift_size:(i+1)*lift_size, j*lift_size:(j+1)*lift_size] = self.get_circulant_mat(lift_size, 0)
+                    else:
+                        while hij_enc > 0:
+                            power = hij_enc % lift_size
+                            h[i*lift_size:(i+1)*lift_size, j*lift_size:(j+1)*lift_size] += self.get_circulant_mat(lift_size, power)
+                            hij_enc = hij_enc // lift_size
+        return h
+    
+    # Draw the Tanner graph of the code.
     def draw_graph(self, draw_edges=True):
 
         pos = nx.get_node_attributes(self.graph, 'pos')
@@ -498,4 +526,155 @@ class BpcCode(QldpcCode):
         self.color_edges()
         return
 
+# Quasi-cyclic lifted product (QLP) code with polynomial entries in the base matrices
+class QlpCode2(QldpcCode):
+    def __init__(self, b1, b2, lift_size):
+        '''
+        :param b1: First base matrix used to construct the lp code. Each entry is the list of powers of the polynomial terms. 
+                   e.g. b1 = [[[0], [0,1], []], [[], [0], [0,1]]] represents the matrix of monomials [[1, 1+x, 0], [0, 1, 1+x]].
+        :param b2: Second base matrix used to construct the lp code. Each entry is the list of powers of the polynomial terms.
+        :param lift_size: Size of cyclic matrix to which each polynomial term is lifted. 
+        '''
+        super().__init__()
+
+        self.b1, self.b2 = b1, b2
+        self.lift_size = lift_size
+
+        self.m1, self.n1 = len(b1), len(b1[0])
+        self.m2, self.n2 = len(b2), len(b2[0])
+
+        # Base matrices where each entry ENCODEs the powers of polynomial terms in base of lift_size
+        b1_enc = np.zeros((self.m1, self.n1), dtype=int)
+        b1T_enc = np.zeros((self.n1, self.m1), dtype=int)
+        b2_enc = np.zeros((self.m2, self.n2), dtype=int)
+        b2T_enc = np.zeros((self.n2, self.m2), dtype=int)
+        b1_enc_placeholder = np.zeros((self.m1, self.n1), dtype=int)
+        b2_enc_placeholder = np.zeros((self.m2, self.n2), dtype=int)
+
+        for i in range(self.m1):
+            for j in range(self.n1):
+                if self.b1[i][j] == []:
+                    continue
+                b1_enc_placeholder[i,j] = 1
+
+                bij, bTij = 0, 0
+                for k in range(len(self.b1[i][j])):
+                    bij += self.lift_size**k * self.b1[i][j][k] 
+                    bTij += self.lift_size**k * (self.lift_size - self.b1[i][j][k]) % self.lift_size
+                b1_enc[i,j] = bij
+                b1T_enc[j,i] = bTij % self.lift_size
+
+        for i in range(self.m2):
+            for j in range(self.n2):
+                if self.b2[i][j] == []:
+                    continue
+                b2_enc_placeholder[i,j] = 1
+
+                bij, bTij = 0, 0
+                for k in range(len(self.b2[i][j])):
+                    bij += self.lift_size**k * self.b2[i][j][k] 
+                    bTij += self.lift_size**k * (self.lift_size - self.b2[i][j][k]) % self.lift_size
+                b2_enc[i,j] = bij
+                b2T_enc[j,i] = bTij % self.lift_size
+
+        hz_base_enc = np.concatenate((np.kron(b2_enc, np.eye(self.n1, dtype=int)), 
+                                  np.kron(np.eye(self.m2, dtype=int), b1T_enc)), axis=1)
+        hx_base_enc = np.concatenate((np.kron(np.eye(self.n2, dtype=int), b1_enc), 
+                                  np.kron(b2T_enc, np.eye(self.m1, dtype=int))), axis=1)
+        hz_base_enc_placeholder = np.concatenate((np.kron(b2_enc_placeholder, np.eye(self.n1, dtype=int)), 
+                                              np.kron(np.eye(self.m2, dtype=int), b1_enc_placeholder.T)), axis=1)
+        hx_base_enc_placeholder = np.concatenate((np.kron(np.eye(self.n2, dtype=int), b1_enc_placeholder), 
+                                              np.kron(b2_enc_placeholder.T, np.eye(self.m1, dtype=int))), axis=1)
+        
+        self.hz = self.lift(self.lift_size, hz_base_enc, hz_base_enc_placeholder)
+        self.hx = self.lift(self.lift_size, hx_base_enc, hx_base_enc_placeholder)
+        self.lz, self.lx = compute_lz_and_lx(self.hx, self.hz)
+
+    def build_graph(self, seed=1):
+
+        super().build_graph()
+        data_qubits, zcheck_qubits, xcheck_qubits = [], [], []
+
+        # Add nodes to the Tanner graph
+        for i in range(self.n1):
+            for j in range(self.n2):
+                for l in range(self.lift_size):
+                    node = (i + j * (self.n1 + self.m1)) * self.lift_size + l 
+                    data_qubits += [node]               
+                    self.graph.add_node(node, pos=(i, j))
+                    self.node_colors += ['blue']
+
+        start = self.n1 * self.lift_size
+        for i in range(self.m1):
+            for j in range(self.n2):
+                for l in range(self.lift_size):
+                    node = start + (i + j * (self.n1 + self.m1)) * self.lift_size + l 
+                    xcheck_qubits += [node]               
+                    self.graph.add_node(node, pos=(i+self.n1, j))
+                    self.node_colors += ['purple']                    
+                    
+        start = self.n2 * (self.n1 + self.m1) * self.lift_size
+        for i in range(self.n1):
+            for j in range(self.m2):
+                for l in range(self.lift_size):
+                    node = start + (i + j * (self.n1 + self.m1)) * self.lift_size + l 
+                    zcheck_qubits += [node]                
+                    self.graph.add_node(node, pos=(i, j+self.n2))
+                    self.node_colors += ['green']
+
+        start = (self.n2 * (self.n1 + self.m1) + self.n1) * self.lift_size        
+        for i in range(self.m1):
+            for j in range(self.m2):
+                for l in range(self.lift_size):
+                    node = start + (i + j * (self.n1 + self.m1)) * self.lift_size + l 
+                    data_qubits += [node]                
+                    self.graph.add_node(node, pos=(i+self.n1, j+self.n2))
+                    self.node_colors += ['blue']
+
+        self.data_qubits = sorted(np.array(data_qubits))
+        self.zcheck_qubits = sorted(np.array(zcheck_qubits))
+        self.xcheck_qubits = sorted(np.array(xcheck_qubits))
+        self.check_qubits = np.concatenate((self.zcheck_qubits, self.xcheck_qubits))
+        self.all_qubits = sorted(np.array(data_qubits + zcheck_qubits + xcheck_qubits))   
+
+        hedge_bool_list = self.get_classical_edge_bools(np.ones(self.b1.shape, dtype=int), seed)
+        vedge_bool_list = self.get_classical_edge_bools(np.ones(self.b2.shape, dtype=int), seed)
     
+        edge_no = 0
+        for i in range(self.m1):
+            for j in range(self.n1):
+                shift = self.b1[i, j]
+                edge_bool = hedge_bool_list[(i, j)]
+
+                for l in range(self.lift_size):
+                    for k in range(self.n2 + self.m2):
+                        if (k < self.n2) ^ edge_bool:
+                            direction_ind = self.direction_inds['E']     
+                        else:
+                            direction_ind = self.direction_inds['W']                                                 
+
+                        control = (k * (self.n1+self.m1) + self.n1 + i) * self.lift_size + (l + shift) % self.lift_size
+                        target = (k * (self.n1+self.m1) + j) * self.lift_size + l
+                        self.add_edge(edge_no, direction_ind, control, target)
+                        edge_no += 1
+
+        for i in range(self.m2):
+            for j in range(self.n2):
+                shift = self.b2[i, j]
+                edge_bool = vedge_bool_list[(i, j)]
+
+                for l in range(self.lift_size):
+                    for k in range(self.n1 + self.m1):
+                        if (k < self.n1) ^ edge_bool:
+                            direction_ind = self.direction_inds['N']     
+                        else:
+                            direction_ind = self.direction_inds['S']   
+
+                        control = (k + j * (self.n1 + self.m1)) * self.lift_size + l
+                        target = (k + (i + self.n2) * (self.n1 + self.m1)) * self.lift_size + (l + shift) % self.lift_size
+                        self.add_edge(edge_no, direction_ind, control, target)
+                        edge_no += 1
+
+        # Color the edges of self.graph
+        self.color_edges()
+        return    


### PR DESCRIPTION
QlpCode2 class is added. The base matrices of the QLP code can now have polynomial entries, which enables simulating lift-connected surface codes (arXiv:2401.02911). This example is added to the [docs/intro.ipynb](https://github.com/mkangquantum/quits/blob/main/doc/intro.ipynb) notebook. 