### PR TITLE
Error rate flexibility

### DIFF
--- a/doc/intro.ipynb
+++ b/doc/intro.ipynb
@@ -126,8 +126,13 @@
     "num_rounds = 15    # number of rounds (T-1)\n",
     "basis = 'Z'        # 'Z' or 'X'\n",
     "\n",
+    "idle_error = p     # Float (DEPOLARIZE1 error with rate p) or tuple of 3 floats (px, py, pz)\n",
+    "sqgate_error = p   # Float (DEPOLARIZE1 error with rate p) or tuple of 3 floats (px, py, pz)\n",
+    "tqgate_error = p   # Float (DEPOLARIZE2 error with rate p) or tuple of 15 floats (pix, ..., pzz)\n",
+    "spam_error = p     # Float\n",
+    "\n",
     "# Generate the memory experiment circuit\n",
-    "circuit = stim.Circuit(get_qldpc_mem_circuit(code, p, p, p, p, num_rounds, basis=basis))\n",
+    "circuit = stim.Circuit(get_qldpc_mem_circuit(code, idle_error, sqgate_error, tqgate_error, spam_error, num_rounds, basis=basis))\n",
     "check_overlapping_CX(circuit)    # Check for overlapping CX gates in the same layer. Nothing should be printed.\n",
     "#print(circuit)"
    ]
@@ -395,7 +400,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.61it/s]"
+      "100%|██████████| 100/100 [00:08<00:00, 11.65it/s]\n"
      ]
     },
     {
@@ -403,13 +408,6 @@
      "output_type": "stream",
      "text": [
       "p: 0.0020000, LFR: 0.0006698\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
      ]
     }
    ],
@@ -450,7 +448,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.48it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 11.63it/s]\n"
      ]
     }
    ],

--- a/src/quits/circuit.py
+++ b/src/quits/circuit.py
@@ -11,10 +11,10 @@ def get_qldpc_mem_circuit(code, idle_error, sqgate_error, tqgate_error, spam_err
     Errors occur at each and every gate. 
 
     :param code: The qldpc_code class from qldpc.py
-    :param idle_error: Rate of depolarizing error
-    :param sqgate_error: Rate of single-qubit gate error
-    :param tqgate_error: Rate of two-qubit gate error
-    :param spam_error: Rate of state preparation and measurement error
+    :param idle_error: Rate of depolarizing error. Float or tuple of 3 floats (px, py, pz)
+    :param sqgate_error: Rate of single-qubit gate error. Float or tuple of 3 floats (px, py, pz)
+    :param tqgate_error: Rate of two-qubit gate error. Float or tuple of 15 floats (pix, ..., pzz)
+    :param spam_error: Rate of state preparation and measurement error. Float
     :param num_rounds: Number of stabilizer measurement rounds
     :param basis: Basis in which logical codewords are stored. Options are 'Z' and 'X'.
     :param get_all_detectors: If True, all detectors in the Z and X bases are obtained. 
@@ -200,7 +200,13 @@ class Circuit:
             return ''
         
         c = self.margin
-        c += 'DEPOLARIZE1(%.10f) '%self.idle_error
+        if type(self.idle_error) == float or type(self.idle_error) == np.float64:
+            c += 'DEPOLARIZE1(%.10f) '%self.idle_error
+        else:
+            c += 'PAULI_CHANNEL_1('
+            for p in self.idle_error:
+                c += '%.10f, '%p
+            c = c[:-2] + ') '
         for q in qubits:
             c += '%d '%q
         c += '\n'
@@ -215,9 +221,15 @@ class Circuit:
             c += '%d '%q
         c += '\n'
         
-        if self.sqgate_error > 0.:
+        if self.sqgate_error != 0. and self.sqgate_error != 0:
             c += self.margin
-            c += 'DEPOLARIZE1(%.10f) '%self.sqgate_error
+            if type(self.sqgate_error) == float or type(self.sqgate_error) == np.float64:
+                c += 'DEPOLARIZE1(%.10f) '%self.sqgate_error
+            else:
+                c += 'PAULI_CHANNEL_1('
+                for p in self.sqgate_error:
+                    c += '%.10f, '%p
+                c = c[:-2] + ') '
             for q in qubits:
                 c += '%d '%q
             c += '\n'
@@ -239,9 +251,15 @@ class Circuit:
             c += '%d '%q
         c += '\n'
         
-        if self.tqgate_error > 0.:
+        if self.tqgate_error != 0. and self.tqgate_error != 0:
             c += self.margin
-            c += 'DEPOLARIZE2(%.10f) '%self.tqgate_error
+            if type(self.tqgate_error) == float or type(self.tqgate_error) == np.float64:
+                c += 'DEPOLARIZE2(%.10f) '%self.tqgate_error
+            else:
+                c += 'PAULI_CHANNEL_2('
+                for p in self.tqgate_error:
+                    c += '%.10f, '%p
+                c = c[:-2] + ') '
             for q in qubits:
                 c += '%d '%q
             c += '\n'


### PR DESCRIPTION
Now `get_qldpc_mem_circuit` accepts a tuple of error rates as `idle_error`, `sqgate_error`, and `tqgate_error`.  