### PR TITLE
Prepare v1.1.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ src/quits/
 
 ## Repo Layout
 
-- `src/quits/` - main package (`python >= 3.10`, package version `1.0.0`)
+- `src/quits/` - main package (`python >= 3.10`, package version `1.1.0`)
 - `tests/` - pytest suite covering codes, circuits, decoders, edge coloration, sliding window, and `cardinalNSmerge`
 - `doc/` - Jupyter notebooks from `00_getting_started.ipynb` through end-to-end demos (`06A`, `06B`)
 - `examples/` - standalone scripts such as circuit-distance search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The project aims to follow Semantic Versioning (SemVer).
 
 ## Unreleased
 
-Changes in this section are relative to `v1.0.0`.
+Changes in this section are relative to `v1.1.0`.
+
+## 1.1.0 - 2026-04-27
 
 ### Added
 - GitHub Actions CI for `pytest` across Python 3.10-3.12.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/quits/
 
 ## Repo Layout
 
-- `src/quits/` - main package (`python >= 3.10`, package version `1.0.0`)
+- `src/quits/` - main package (`python >= 3.10`, package version `1.1.0`)
 - `tests/` - pytest suite covering codes, circuits, decoders, edge coloration, sliding window, and `cardinalNSmerge`
 - `doc/` - Jupyter notebooks from `00_getting_started.ipynb` through end-to-end demos (`06A`, `06B`)
 - `examples/` - standalone scripts such as circuit-distance search

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 QUITS is a modular and flexible circuit-level simulator for quantum low-density parity-check (QLDPC) codes. It is designed so users can choose and mix different options for each module independently: code construction, circuit strategy, decoder, noise model, and layout helper.
 
 *Example QLDPC code (Balanced Product Cyclic code) Tanner graph with cardinal circuit scheduling and transversal layout.*
-![BPC Tanner graph with cardinal circuit scheduling and transversal layout](https://raw.githubusercontent.com/mkangquantum/quits/v1.0.0/doc/assets/readme_graph.png)
+![BPC Tanner graph with cardinal circuit scheduling and transversal layout](https://raw.githubusercontent.com/mkangquantum/quits/v1.1.0/doc/assets/readme_graph.png)
 
 
 ## Modular Architecture
@@ -25,12 +25,12 @@ For HGP codes, QUITS also includes a classical LDPC generator in `quits.ldpc_uti
 
 Supported code families include:
 
-- [Hypergraph Product (HGP) codes](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01A_codes_basics.ipynb)
-- [Quasi-cyclic Lifted Product (QLP) codes](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01A_codes_basics.ipynb)
-- [Balanced Product Cyclic (BPC) codes](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01A_codes_basics.ipynb)
-- [Lift-Connected Surface (LCS) codes](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01A_codes_basics.ipynb)
-- [Bivariate Bicycle (BB) codes](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01A_codes_basics.ipynb)
-- [**Any code**, if you bring the parity check matrices](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/01B_make_my_own_code.ipynb)
+- [Hypergraph Product (HGP) codes](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01A_codes_basics.ipynb)
+- [Quasi-cyclic Lifted Product (QLP) codes](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01A_codes_basics.ipynb)
+- [Balanced Product Cyclic (BPC) codes](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01A_codes_basics.ipynb)
+- [Lift-Connected Surface (LCS) codes](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01A_codes_basics.ipynb)
+- [Bivariate Bicycle (BB) codes](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01A_codes_basics.ipynb)
+- [**Any code**, if you bring the parity check matrices](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/01B_make_my_own_code.ipynb)
 
 For background on QUITS, see [arXiv:2504.02673](https://arxiv.org/abs/2504.02673).
 
@@ -46,9 +46,9 @@ For background on QUITS, see [arXiv:2504.02673](https://arxiv.org/abs/2504.02673
 | BB | yes | no | yes |
 | Any | yes | no | no |
 
-- [`zxcoloration`](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/02C_zxcoloration_circuit_generation.ipynb) is available for all QLDPC codes.
-- [`cardinal`, `cardinalNSmerge`](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/02B_cardinal_circuit_generation.ipynb) are available for HGP, QLP, BPC, and LCS.
-- [`custom`](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/02A_custom_circuit_generation.ipynb) is available for BB code.
+- [`zxcoloration`](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/02C_zxcoloration_circuit_generation.ipynb) is available for all QLDPC codes.
+- [`cardinal`, `cardinalNSmerge`](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/02B_cardinal_circuit_generation.ipynb) are available for HGP, QLP, BPC, and LCS.
+- [`custom`](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/02A_custom_circuit_generation.ipynb) is available for BB code.
 
 
 ## Recommended Companion Libraries
@@ -76,7 +76,7 @@ pip install -e .
 
 ## Quick Start Docs
 
-- [doc/00_getting_started.ipynb](https://github.com/mkangquantum/quits/blob/v1.0.0/doc/00_getting_started.ipynb)
+- [doc/00_getting_started.ipynb](https://github.com/mkangquantum/quits/blob/v1.1.0/doc/00_getting_started.ipynb)
 
 ## Acknowledgments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quits"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   { name = "Mingyu Kang", email = "mingyu.kang@duke.edu" },
   { name = "Yingjia Lin", email = "yingjia.lin@duke.edu" },
@@ -39,7 +39,7 @@ dependencies = [
 Homepage = "https://github.com/mkangquantum/quits"
 Source = "https://github.com/mkangquantum/quits"
 Issues = "https://github.com/mkangquantum/quits/issues"
-Changelog = "https://github.com/mkangquantum/quits/blob/v1.0.0/CHANGELOG.md"
+Changelog = "https://github.com/mkangquantum/quits/blob/v1.1.0/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

  Prepares the `v1.1.0` release by updating package metadata, release docs, and versioned links.

  ## Changes

  - bump package version from `1.0.0` to `1.1.0` in `pyproject.toml`
  - update the changelog with the `1.1.0` release entry dated `2026-04-27`
  - preserve the `Unreleased` section so future changes remain relative to `v1.1.0`
  - update README links and asset references from `v1.0.0` to `v1.1.0`
  - sync `AGENTS.md` and `CLAUDE.md` package-version references to `1.1.0`

  ## Validation

  - `python -m pytest -q`
  - `python -m build`

  ## Notes

  - build succeeded for `1.1.0`
  - setuptools emitted non-blocking deprecation warnings about the `project.license` table/
  classifiers in `pyproject.toml`; this can be cleaned up separately